### PR TITLE
Allow add data at repo level

### DIFF
--- a/settings/opendal.yml
+++ b/settings/opendal.yml
@@ -1,5 +1,0 @@
-# Apache OpenDAL settings file
-
-# List of GitHub organizations to scan for contributions
-repositories:
-  - apache/opendal

--- a/settings/opendal.yml
+++ b/settings/opendal.yml
@@ -1,0 +1,5 @@
+# Apache OpenDAL settings file
+
+# List of GitHub organizations to scan for contributions
+repositories:
+  - apache/opendal

--- a/src/build/github.rs
+++ b/src/build/github.rs
@@ -1,6 +1,7 @@
 //! This module is in charge of collecting contributions from GitHub.
 
 use crate::build::db;
+use crate::build::settings::Settings;
 use anyhow::{bail, ensure, Context, Result};
 use chrono::DateTime;
 use deadpool::unmanaged::{Object, Pool};
@@ -18,7 +19,6 @@ use std::{
 };
 use tempfile::NamedTempFile;
 use tracing::{debug, instrument, trace};
-use crate::build::settings::Settings;
 
 /// GitHub API base url.
 const API_BASE_URL: &str = "https://api.github.com";
@@ -71,7 +71,10 @@ impl Collector {
         }
         for repo in &settings.repositories {
             let pair = repo.split('/').collect::<Vec<&str>>();
-            ensure!(pair.len() == 2, "repository format must be owner/repo, found: {repo}");
+            ensure!(
+                pair.len() == 2,
+                "repository format must be owner/repo, found: {repo}"
+            );
             repositories.push((pair[0].to_string(), pair[1].to_string()));
         }
 

--- a/src/build/github.rs
+++ b/src/build/github.rs
@@ -70,10 +70,8 @@ impl Collector {
             repositories.extend(self.list_repositories(org).await?);
         }
         for repo in &settings.repositories {
-            let pair = repo.splitn(2, '/').collect::<Vec<&str>>();
+            let pair = repo.split('/').collect::<Vec<&str>>();
             ensure!(pair.len() == 2, "repository format must be owner/repo, found: {repo}");
-            ensure!(!pair[0].contains('/'), "owner cannot contain a slash, found: {}", pair[0]);
-            ensure!(!pair[1].contains('/'), "repo cannot contain a slash, found: {}", pair[1]);
             repositories.push((pair[0].to_string(), pair[1].to_string()));
         }
 

--- a/src/build/github.rs
+++ b/src/build/github.rs
@@ -1,7 +1,7 @@
 //! This module is in charge of collecting contributions from GitHub.
 
 use crate::build::db;
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, ensure, Context, Result};
 use chrono::DateTime;
 use deadpool::unmanaged::{Object, Pool};
 use duckdb::{AccessMode, Config, OptionalExt};
@@ -71,6 +71,9 @@ impl Collector {
         }
         for repo in settings.repositories.iter() {
             let pair = repo.splitn(2, '/').collect::<Vec<&str>>();
+            ensure!(pair.len() == 2, "repository format must be owner/repo, found: {repo}");
+            ensure!(!pair[0].contains("/"), "owner cannot contain a slash, found: {}", pair[0]);
+            ensure!(!pair[1].contains("/"), "repo cannot contain a slash, found: {}", pair[1]);
             repositories.push((pair[0].to_string(), pair[1].to_string()));
         }
 

--- a/src/build/github.rs
+++ b/src/build/github.rs
@@ -66,14 +66,14 @@ impl Collector {
 
         // Fetch organizations' repositories
         let mut repositories = vec![];
-        for org in settings.organizations.iter() {
+        for org in &settings.organizations {
             repositories.extend(self.list_repositories(org).await?);
         }
-        for repo in settings.repositories.iter() {
+        for repo in &settings.repositories {
             let pair = repo.splitn(2, '/').collect::<Vec<&str>>();
             ensure!(pair.len() == 2, "repository format must be owner/repo, found: {repo}");
-            ensure!(!pair[0].contains("/"), "owner cannot contain a slash, found: {}", pair[0]);
-            ensure!(!pair[1].contains("/"), "repo cannot contain a slash, found: {}", pair[1]);
+            ensure!(!pair[0].contains('/'), "owner cannot contain a slash, found: {}", pair[0]);
+            ensure!(!pair[1].contains('/'), "repo cannot contain a slash, found: {}", pair[1]);
             repositories.push((pair[0].to_string(), pair[1].to_string()));
         }
 

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -41,7 +41,7 @@ pub(crate) async fn build(args: &BuildArgs) -> Result<()> {
     // Collect contributions from GitHub
     if args.collect_contributions.unwrap_or(true) {
         let collector = github::Collector::new(&cache_db_file)?;
-        collector.collect_contributions(&settings.organizations).await?;
+        collector.collect_contributions(&settings).await?;
     }
     let contribs_db = prepare_contributions_table(&cache_db_file)?;
 

--- a/src/build/settings.rs
+++ b/src/build/settings.rs
@@ -7,7 +7,10 @@ use std::{fs::File, path::Path};
 /// ContribCard settings.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub(crate) struct Settings {
+    #[serde(default)]
     pub organizations: Vec<String>,
+    #[serde(default)]
+    pub repositories: Vec<String>,
 }
 
 impl Settings {


### PR DESCRIPTION
Ideas: Using GraphQL may speed up the script by reducing a lot of bytes transferred that are unused.