### PR TITLE
feat: ignore casing

### DIFF
--- a/web/src/layout/contributor/index.tsx
+++ b/web/src/layout/contributor/index.tsx
@@ -3,8 +3,10 @@ import { createSignal, JSXElement, Match, onCleanup, onMount, Show, Switch } fro
 
 import API from '../../api';
 import clotributor from '../../assets/clotributor.png';
+import { useContributorsDataInfo } from '../../stores/contributorsData';
 import { ContributionKind, Contributor } from '../../types';
 import prettifyNumber from '../../utils/prettifyNumber';
+import resolveContributorId from '../../utils/resolveContributorId';
 import updateMetaTags from '../../utils/updateMetaTags';
 import ExternalLink from '../common/ExternalLink';
 import Image from '../common/Image';
@@ -63,7 +65,10 @@ const ContributionKindIcon = (props: Props): JSXElement => {
 const ContributorCard = () => {
   const location = useLocation();
   const params = useParams();
+  const contributorsInfo = useContributorsDataInfo();
   const [contributor, setContributor] = createSignal<Contributor | null | undefined>();
+
+  const resolveId = (id: string): string => resolveContributorId(id, contributorsInfo());
 
   const getFirstContributionLink = () => {
     let url = `https://github.com/${contributor()!.first_contribution.owner}/${
@@ -96,7 +101,7 @@ const ContributorCard = () => {
 
   onMount(() => {
     if (contributor() === undefined) {
-      fecthContributorInfo(params.id);
+      fecthContributorInfo(resolveId(params.id));
     }
     updateMetaTags(`${window.location.origin}${location.pathname}`);
   });

--- a/web/src/layout/search/index.tsx
+++ b/web/src/layout/search/index.tsx
@@ -7,6 +7,7 @@ import {
   useContributorsDataLoader,
 } from '../../stores/contributorsData';
 import prettifyNumber from '../../utils/prettifyNumber';
+import resolveContributorId from '../../utils/resolveContributorId';
 import updateMetaTags from '../../utils/updateMetaTags';
 import HoverableItem from '../common/HoverableItem';
 import Image from '../common/Image';
@@ -108,7 +109,7 @@ const Search = () => {
     cleanItemsSearch();
     setValue('');
     forceBlur();
-    navigate(`/${contributorId}`, {
+    navigate(`/${resolveContributorId(contributorId, contributorsInfo())}`, {
       replace: false,
       scroll: true, // default
     });

--- a/web/src/utils/resolveContributorId.ts
+++ b/web/src/utils/resolveContributorId.ts
@@ -1,0 +1,12 @@
+import { UserInfo } from '../types';
+
+const resolveContributorId = (id: string, info: UserInfo | null | undefined): string => {
+  if (info) {
+    const lower = id.toLowerCase();
+    const canonical = Object.keys(info).find((k) => k.toLowerCase() === lower);
+    if (canonical) return canonical;
+  }
+  return id.toLowerCase();
+};
+
+export default resolveContributorId;


### PR DESCRIPTION
Hey team! Thanks for this great project!
This PR is an attempt to fix: #82 

This PR handles GitHub usernames in a case-insensitive manner so that `/maxday` and `/MaxDay` both resolve to the correct contributor card. 
This PR adds a shared `resolveContributorId` utility that performs a case-insensitive lookup against the contributors map, used in both the search and contributor card components.

I tried it locally and it works, let me know if you need more details! :)

<img width="838" height="802" alt="Screenshot 2026-03-22 at 6 22 22 PM" src="https://github.com/user-attachments/assets/7c185595-87ce-4401-aee0-9adc9eb35455" />
